### PR TITLE
Ready to release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ script:
 
 # These directories are cached to S3 at the end of the build
 cache:
+  timeout: 86400
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+    - $HOME/.sbt
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - version=36
 
 script:
-  - sbt "+nitf${version}/compile" "nitf${version}Test/test"
+  - sbt "+nitf${version}Test/test"
 
 # These directories are cached to S3 at the end of the build
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 jdk: oraclejdk8
+scala:
+  - 2.11.12
+  - 2.12.4
 git:
   depth: 1
 
@@ -11,7 +14,7 @@ env:
     - version=36
 
 script:
-  - sbt "+nitf${version}Test/test"
+  - sbt "++$TRAVIS_SCALA_VERSION" "nitf${version}Test/test"
 
 # These directories are cached to S3 at the end of the build
 cache:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to nitf-scala
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+Your contributions are most welcome. Please feel free to open issues or submit pull requests.
+
+## Project Structure
+
+The project build definition is in [project/Build.scala](project/Build.scala),
+where a sub-project is dynamically generated for each version of NITF.
+
+The build is defined to cross-compile against Scala 2.11 and 2.12.
+
+The schema definition for each supported version of NITF is in the [schema](schema) directory.
+These files are used to generate the Scala classes using ScalaXB as described in the [README](README.md#generated-sources).
+
+There is one test class that reads an example specific to each version.
+The test class is in [Tests/src/test/scala](Tests/src/test/scala).
+The examples are in [Tests/src/test/resources](Tests/src/test/resources).
+
+## Continuous Integration
+
+The project is [configured](.travis.yml) to run on Travis CI.
+The matrix is configured to build each version of NITF separately.
+This helps speed up the build dramatically.
+
+## Releasing
+
+To release this project, run:
+```bash
+sbt "release with-defaults"
+```
+
+Releasing is currently [configured](project/Build.scala) to publish locally only.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2018 Guardian News & Media Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ sbt clean +compile +test
 ```
 Note that a clean build may take up to 10 minutes.
 You may also need to increase the memory available to sbt (e.g. using `-mem`).  
-(The full compilation has more than 24k classes files!)
+(The full compilation has more than 24k class files!)
 
 The project is set up to build against Scala 2.11 and Scala 2.12.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The schemas used to generate the classes in this project are available in the [s
 
 ## Generated Sources
 
-The source files were generated using a
-[custom version of ScalaXB](https://github.com/hosamaly/scalaxb/archive/bd92a411fa863815019a216d23f7b8d9d342b27b.zip)
+The source files were generated using an
+[unreleased version of ScalaXB](https://github.com/eed3si9n/scalaxb/archive/5d0eea5a6c4d713976c9b86cc2cb691d0f83e137.zip)
 that was built from source. Hopefully, it will be released in the main repository soon.
 
 The following command was used to generate the files for each version:
@@ -65,16 +65,12 @@ done
 
 ## Building
 
-To build this project, run:
+To build this project from source, run:
 ```bash
-sbt clean +compile test
+sbt clean +compile +test
 ```
-Note that a clean build may take up to 10 minutes.  
-(The full compilation has more than 23k classes!)
+Note that a clean build may take up to 10 minutes.
+You may also need to increase the memory available to sbt (e.g. using `-mem`).  
+(The full compilation has more than 24k classes files!)
 
-The compiled sources are cross-built against Scala 2.11 and 2.12.
-
-The tests are built against Scala 2.11 only.
-Hopefully, this will change as soon as
-[scala-xml-diff](https://github.com/andyglow/scala-xml-diff)
-is released for 2.12.
+The project is set up to build against Scala 2.11 and Scala 2.12.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # nitf-scala
+[![License: Apache-2.0](https://img.shields.io/github/license/guardian/nitf-scala.svg)](https://github.com/guardian/nitf-scala/blob/master/LICENSE)
 [![Build Status](https://travis-ci.org/guardian/nitf-scala.svg?branch=master)](https://travis-ci.org/guardian/nitf-scala)
+<!--
+![Maven Metadata](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/com/gu/nitf-scala/maven-metadata.xml.svg)
+-->
 
 Scala library to parse and generate [News Industry Text Format](https://iptc.org/standards/nitf/) files,
 based on [ScalaXB](http://scalaxb.org).
@@ -38,7 +42,7 @@ val xml = scalaxb.toXML(doc, namespace = None, elementLabel = Some("nitf"), scop
 NITF schema, documentation, and examples are available from IPTC.
 [This archive](http://www.iptc.org/std/NITF/NITF.zip) contains all of this for versions 2.5 to 3.6.
 
-The schemas used to generate the classes in this project are available in the [schema](schema/) folder.
+The schemas used to generate the classes in this project are available in the [schema](schema) folder.
 
 ## Generated Sources
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,1 @@
-import Build._
-
-inThisBuild(Seq(
-  organization := "com.gu",
-  scalaVersion := Dependencies.scalaVersions.min
-))
+// project definitions are dynamically generated in project/Build.scala

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,34 +2,87 @@ import sbt._
 import sbt.Keys._
 import sbt.internal.BuildDef
 
-import net.vonbuchholtz.sbt.dependencycheck.DependencyCheckPlugin.autoImport.dependencyCheckFailBuildOnCVSS
+import net.vonbuchholtz.sbt.dependencycheck.DependencyCheckPlugin.autoImport._
+import sbtrelease.ReleasePlugin.autoImport._
+import sbtrelease.ReleaseStateTransformations._
+import xerial.sbt.Sonatype.autoImport._
 
+/** Creates a dynamic project for each schema version, and configures the common tests for all projects.
+  *
+  * The main projects are cross-compiled but the tests aren't because of a test dependency that isn't available for 2.12.
+  * Releasing, publishing, and checking for insecure dependencies are disabled for test projects.
+  * The root project is just an empty shell to run aggregated commands.
+  *
+  * The release process is customised to include a step to run ''dependencyCheck''.
+  */
 object Build extends BuildDef with BuildCommon {
-  override def projects: Seq[Project] = mainProjects ++ testProjects
+  private val schemaVersions = Seq("3.3", "3.4", "3.5", "3.6")
+
   lazy val mainProjects: Seq[Project] = schemaVersions.map(nitfProject)
   lazy val testProjects: Seq[Project] = schemaVersions.map(testProject)
+  lazy val realProjects: Seq[Project] = mainProjects ++ testProjects
 
-  private val releaseVersion = 0
-  private val schemaVersions = Seq("3.3", "3.4", "3.5", "3.6")
+  override def projects: Seq[Project] = rootProject.toSeq ++ realProjects
+  override def rootProject = Some(
+    Project(id = "nitf-scala", base = file("."))
+      .aggregate(realProjects.map(Project.projectToRef): _*)
+      .settings(commonSettings ++ disabledPublishingSettings)
+      .settings(
+        crossScalaVersions := Dependencies.scalaVersions,
+        releaseProcess := releasingProcess,
+        releaseCrossBuild := true
+      )
+  )
+
+  private lazy val commonSettings = Seq(
+    organization := "com.gu",
+    licenses += "Apache-2.0" -> url("https://choosealicense.com/licenses/apache-2.0/"),
+    crossScalaVersions := Dependencies.scalaVersions,
+    scalaVersion := Dependencies.scalaVersions.min,
+    scalacOptions += "-target:jvm-1.8",
+
+    dependencyCheckFailBuildOnCVSS := 4,
+    publishTo := sonatypePublishTo.value,
+    releasePublishArtifactsAction := publishLocal.value  // TODO remove this when we're ready to publish publicly
+  )
 
   private val commonDependencies = Dependencies.xmlParsing
 
-  private lazy val mainSettings = Seq(
-    crossScalaVersions := Dependencies.scalaVersions,
-    libraryDependencies ++= commonDependencies,
-    dependencyCheckFailBuildOnCVSS := 4
+  private lazy val mainSettings = commonSettings ++ Seq(
+    libraryDependencies ++= commonDependencies
   )
 
-  private lazy val testSettings = Seq(
+  private lazy val testSettings = commonSettings ++ disabledPublishingSettings ++ Seq(
     fork := true,
-    crossVersion := Disabled(),  // scala-xml-diff is released for 2.11 only
-    libraryDependencies ++= commonDependencies ++ Dependencies.testing
+    libraryDependencies ++= commonDependencies ++ Dependencies.testing,
+    dependencyCheckSkip := true
+  )
+
+  private lazy val disabledPublishingSettings = Seq(
+    publish := {},
+    publishLocal := {},
+    publishArtifact := false
+  )
+
+  private val releasingProcess = Seq[ReleaseStep](ReleaseStep(identity)  /* no-op */
+    , checkSnapshotDependencies
+    , releaseStepTask(dependencyCheckAggregate)
+    , inquireVersions
+    , runClean
+    , runTest
+    , setReleaseVersion
+//  , commitReleaseVersion
+//  , tagRelease
+    , publishArtifacts
+//  , setNextVersion
+//  , commitNextVersion
+//  ,  pushChanges
   )
 
   private def nitfProject(schemaVersion: String): Project = {
     Project(id = projectId(schemaVersion), base = file(schemaVersion))
       .settings(mainSettings)
-      .settings(version := s"$schemaVersion.$releaseVersion")
+      .settings(version := s"$schemaVersion.${(ThisBuild/version).value}")
   }
 
   private def testProject(schemaVersion: String): Project = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,7 +25,7 @@ object Build extends BuildDef with BuildCommon {
 
   override def projects: Seq[Project] = rootProject.toSeq ++ realProjects
   override def rootProject = Some(
-    Project(id = "nitf-scala", base = file("."))
+    Project(id = Metadata.projectName, base = file("."))
       .aggregate(realProjects.map(Project.projectToRef): _*)
       .settings(commonSettings ++ disabledPublishingSettings)
       .settings(
@@ -35,10 +35,7 @@ object Build extends BuildDef with BuildCommon {
       )
   )
 
-  private lazy val commonSettings = Seq(
-    organization := "com.gu",
-    licenses += "Apache-2.0" -> url("https://choosealicense.com/licenses/apache-2.0/"),
-
+  private lazy val commonSettings = Metadata.settings ++ Seq(
     crossScalaVersions := Dependencies.scalaVersions,
     scalaVersion := Dependencies.scalaVersions.min,
     scalacOptions += "-target:jvm-1.8",
@@ -61,11 +58,14 @@ object Build extends BuildDef with BuildCommon {
     dependencyCheckSkip := true
   )
 
-  private lazy val disabledPublishingSettings = Seq(
+  private lazy val disabledPublishingSettings = { import PgpKeys._; Seq(
     publish := {},
     publishLocal := {},
-    publishArtifact := false
-  )
+    publishSigned := {},
+    publishLocalSigned := {},
+    publishArtifact := false,
+    sonatypePublishTo := None
+  )}
 
   private val releasingProcess = Seq[ReleaseStep](ReleaseStep(identity)  /* no-op */
     , checkSnapshotDependencies

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,6 +2,7 @@ import sbt._
 import sbt.Keys._
 import sbt.internal.BuildDef
 
+import com.typesafe.sbt.SbtPgp.autoImport._
 import net.vonbuchholtz.sbt.dependencycheck.DependencyCheckPlugin.autoImport._
 import sbtrelease.ReleasePlugin.autoImport._
 import sbtrelease.ReleaseStateTransformations._
@@ -29,21 +30,23 @@ object Build extends BuildDef with BuildCommon {
       .settings(commonSettings ++ disabledPublishingSettings)
       .settings(
         crossScalaVersions := Dependencies.scalaVersions,
-        releaseProcess := releasingProcess,
-        releaseCrossBuild := true
+        releaseCrossBuild := true,
+        releaseProcess := releasingProcess
       )
   )
 
   private lazy val commonSettings = Seq(
     organization := "com.gu",
     licenses += "Apache-2.0" -> url("https://choosealicense.com/licenses/apache-2.0/"),
+
     crossScalaVersions := Dependencies.scalaVersions,
     scalaVersion := Dependencies.scalaVersions.min,
     scalacOptions += "-target:jvm-1.8",
 
     dependencyCheckFailBuildOnCVSS := 4,
+
     publishTo := sonatypePublishTo.value,
-    releasePublishArtifactsAction := publishLocal.value  // TODO remove this when we're ready to publish publicly
+    releasePublishArtifactsAction := PgpKeys.publishLocalSigned.value  // TODO remove this when we're ready to publish publicly
   )
 
   private val commonDependencies = Dependencies.xmlParsing

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -43,12 +43,13 @@ object Build extends BuildDef with BuildCommon {
     dependencyCheckFailBuildOnCVSS := 4,
 
     publishTo := sonatypePublishTo.value,
-    releasePublishArtifactsAction := PgpKeys.publishLocalSigned.value  // TODO remove this when we're ready to publish publicly
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value
   )
 
   private val commonDependencies = Dependencies.xmlParsing
 
   private lazy val mainSettings = commonSettings ++ Seq(
+    name := "nitf-scala",
     libraryDependencies ++= commonDependencies
   )
 
@@ -68,18 +69,18 @@ object Build extends BuildDef with BuildCommon {
   )}
 
   private val releasingProcess = Seq[ReleaseStep](ReleaseStep(identity)  /* no-op */
+    , runClean
     , checkSnapshotDependencies
     , releaseStepTask(dependencyCheckAggregate)
     , inquireVersions
-    , runClean
     , runTest
     , setReleaseVersion
-//  , commitReleaseVersion
-//  , tagRelease
+    , commitReleaseVersion
+    , tagRelease
     , publishArtifacts
-//  , setNextVersion
-//  , commitNextVersion
-//  ,  pushChanges
+    , setNextVersion
+    , commitNextVersion
+    , pushChanges
   )
 
   private def nitfProject(schemaVersion: String): Project = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,9 +16,7 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion
   val scalactic = "org.scalactic" %% "scalactic" % scalaTestVersion
 
-  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4"
+  val xmlDiff = "com.github.andyglow" %% "scala-xml-diff" % "2.0.3"
 
-  val xmlDiff = "com.github.andyglow" %% "scala-xml-diff" % "2.0.2"
-
-  val testing = Seq(scalaTest, scalaCheck, xmlDiff).map(_ % Test)
+  val testing = Seq(scalaTest, xmlDiff).map(_ % Test)
 }

--- a/project/Metadata.scala
+++ b/project/Metadata.scala
@@ -1,0 +1,27 @@
+import sbt._
+import sbt.Keys._
+
+object Metadata {
+  val gitHubUser = "guardian"
+  val projectName = "nitf-scala"
+
+  lazy val settings = Seq(
+    organization := "com.gu",
+    organizationName := "Guardian News & Media Ltd",
+    organizationHomepage := Some(url("https://www.theguardian.com/")),
+
+    startYear := Some(2018),
+    licenses += "Apache-2.0" -> url("https://choosealicense.com/licenses/apache-2.0/"),
+
+    scmInfo := Some(ScmInfo(
+      url(s"https://github.com/$gitHubUser/$projectName"),
+      s"scm:git@github.com:$gitHubUser/$projectName.git"
+    )),
+
+    homepage := scmInfo.value.map(_.browseUrl),
+
+    developers := List(
+      Developer(id = "hosamaly", name = "Hosam Aly", email = null, url = url("https://github.com/hosamaly"))
+    )
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,4 @@
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
+
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "0.2.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0-SNAPSHOT"


### PR DESCRIPTION
The project has been configured for releasing.
It's [being built on Travis CI](https://travis-ci.org/guardian/nitf-scala).
It's also published to Sonatype snapshots ([for 2.12](https://oss.sonatype.org/content/repositories/snapshots/com/gu/nitf34_2.12/3.4.0-SNAPSHOT/) and [for 2.11](https://oss.sonatype.org/content/repositories/snapshots/com/gu/nitf36_2.11/3.6.0-SNAPSHOT/)).